### PR TITLE
Replace `pub` with `dart pub`

### DIFF
--- a/lib/src/cli_notify_base.dart
+++ b/lib/src/cli_notify_base.dart
@@ -51,7 +51,7 @@ class Notify {
       final needUpdate = comparison < 0;
 
       if (needUpdate) {
-        final updateCmd = 'pub global activate $packageName'.cyan();
+        final updateCmd = 'dart pub global activate $packageName'.cyan();
         final current = '$currentVersion'.grey();
         final latest = '$latestVersion'.green();
 


### PR DESCRIPTION
Standalone `pub` was removed a few releases ago